### PR TITLE
Fixed the tag of catalog container image

### DIFF
--- a/ch10/catalog-deployment-v2.yaml
+++ b/ch10/catalog-deployment-v2.yaml
@@ -27,7 +27,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: istioinaction/catalog:latency
+        image: istioinaction/catalog:latest 
         imagePullPolicy: IfNotPresent
         name: catalog
         ports:


### PR DESCRIPTION
The tag of "catalog" container image specified in ch10/catalog-deployment-v2.yaml is missing from dockerhub and "latest" tag seems to work.