### PR TITLE
refactor: reduce container image size for catalog

### DIFF
--- a/services/catalog/Dockerfile
+++ b/services/catalog/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:14
+# Base image for multi-stage build
+FROM node:14-alpine AS BUILD_IMAGE
 LABEL maintainer="Christian Posta <christian.posta@gmail.com>" 
 
 RUN npm install json-server@0.14.2 faker@4.1.0
@@ -6,12 +7,17 @@ RUN npm install json-server@0.14.2 faker@4.1.0
 WORKDIR /usr/src/app
 VOLUME /usr/src/app
 
-COPY package*.json /usr/src/app/
+COPY package.json /usr/src/app/
 RUN npm install
 
-EXPOSE 3000
-
+# Final image
+FROM node:14-alpine
+WORKDIR /usr/src/app
+# Copy build artifacts from BUILD_IMAGE
+COPY --from=BUILD_IMAGE /usr/src/app/ /usr/src/app/
+COPY --from=BUILD_IMAGE /node_modules /node_modules
 COPY *.js /usr/src/app/
 
+EXPOSE 3000
 ENTRYPOINT ["node", "server.js"]
 CMD []


### PR DESCRIPTION
Hi
Proposing changes to the Dockerfile to reduce the size of the container image
List of changes
1. Base image changed to `node14:alpine`
2. Implemented multi-stage build

Image size reduced from 1.01 GB to 142 Mb
fixes #20 
Signed-off-by: Vladimir Belousov <vbelouso@redhat.com>