### PR TITLE
fix: fixing hosts in ch5 virtual service

### DIFF
--- a/ch5/catalog-vs-v1-mesh.yaml
+++ b/ch5/catalog-vs-v1-mesh.yaml
@@ -4,7 +4,7 @@ metadata:
   name: catalog
 spec:
   hosts:
-  - catalog
+  - catalog.istioinaction.io
   gateways:
     - mesh
   http:


### PR DESCRIPTION
In Ch5, Mirroring Request

The `curl` request is getting blocked at the Gateway due to Host mismatch at the Virtual Service.
```
$ curl http://localhost/api/catalog -H "Host: webapp.istioinaction.io"
```